### PR TITLE
Sync workspaces with authenticated user state

### DIFF
--- a/ui/src/context/WorkspaceProvider.tsx
+++ b/ui/src/context/WorkspaceProvider.tsx
@@ -1,6 +1,7 @@
 import {
   Accessor,
   createContext,
+  createEffect,
   createMemo,
   createSignal,
   JSXElement,
@@ -10,6 +11,7 @@ import {
 import { getWorkspaces } from '../api'
 import { WorkspaceListItemAttributes } from '../models/Workspace'
 import type { FrozenReason } from '../models/Workspace'
+import { useUser } from './UserProvider'
 
 interface WorkspaceContextAttributes {
   workspaces: Accessor<WorkspaceListItemAttributes[]>
@@ -27,6 +29,7 @@ interface WorkspaceContextAttributes {
 const WorkspaceContext = createContext<WorkspaceContextAttributes | null>(null)
 
 export const WorkspaceProvider = (props: { children: JSXElement }) => {
+  const { user } = useUser()
   const [workspaces, setWorkspaces] = createSignal<
     WorkspaceListItemAttributes[]
   >([])
@@ -77,6 +80,18 @@ export const WorkspaceProvider = (props: { children: JSXElement }) => {
     setCurrentWorkspace(workspace)
     localStorage.setItem('currentWorkspaceId', String(workspace.id))
   }
+
+  // Keep workspaces in sync with the authenticated user so any entry point
+  // (login, page refresh, deep link) ends up with a populated dropdown and
+  // a selected workspace without each page having to fetch on its own.
+  createEffect(() => {
+    if (user()) {
+      void fetchWorkspaces()
+    } else {
+      setWorkspaces([])
+      setCurrentWorkspace(null)
+    }
+  })
 
   return (
     <WorkspaceContext.Provider


### PR DESCRIPTION
## Summary
Added automatic synchronization of workspaces with the authenticated user state in the WorkspaceProvider. This ensures that workspaces are fetched when a user logs in and cleared when they log out, providing a consistent experience across all entry points without requiring individual pages to manage their own workspace fetching logic.

## Key Changes
- Imported `useUser` hook and `createEffect` from Solid.js dependencies
- Added user state tracking to WorkspaceProvider by calling `useUser()`
- Implemented a `createEffect` that monitors user authentication state and:
  - Fetches workspaces when a user becomes authenticated
  - Clears workspaces and current workspace selection when user logs out

## Implementation Details
The effect automatically triggers whenever the user state changes, ensuring that:
- Login/page refresh/deep linking all result in a populated workspace dropdown
- The current workspace is properly selected without requiring per-page fetch logic
- Workspace state is cleaned up on logout to prevent stale data

https://claude.ai/code/session_01UeKYk9CggLMLp6uME1WW1S